### PR TITLE
Use drop-down for Spot: Terminate

### DIFF
--- a/src/spotTerminate.ts
+++ b/src/spotTerminate.ts
@@ -16,11 +16,10 @@ export class MissingConfigVariablesError extends Error {}
 export class ACIDeleteError extends Error {}
 
 export async function spotTerminate(azureSub: AzureSubscription, knownSpots: KnownSpots): Promise<void> {
-    // tslint:disable-next-line:max-line-length
-    const spotNamePrompt = Object.keys(knownSpots.getAll()).length > 0 ? `Known spots: ${Array.from(Object.keys(knownSpots.getAll()))}` : undefined;
-    const spotName: string | undefined = await window.showInputBox({placeHolder: 'Name of spot to terminate/delete.',
-                                                                    ignoreFocusOut: true,
-                                                                    prompt: spotNamePrompt});
+    const knownSpotsKeys = Object.keys(knownSpots.getAll());
+    const spotName: string | undefined = await window.showQuickPick(Array.from(knownSpotsKeys),
+                                                                    {placeHolder: 'Name of spot to terminate/delete.',
+                                                                    ignoreFocusOut: true});
     if (!spotName) {
         throw new UserCancelledError('No spot name specified. Operation cancelled.');
     }


### PR DESCRIPTION
Closes https://github.com/derekbekoe/vscode-spot/issues/43

Cannot use the same for 'Spot: Connect' because we need to allow custom text as well as the quick pick options and `window.showQuickPick()` does not seem to allow accepting text that is not one of the options (https://code.visualstudio.com/docs/extensionAPI/vscode-api#_window).