### PR TITLE
added azure tags to get more visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Spot",
     "description": "Instant cloud environments for developers.",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "publisher": "derek-bekoe",
     "galleryBanner": {
         "color": "#3f51b5",
@@ -22,14 +22,15 @@
         "vscode": "^1.22.0"
     },
     "categories": [
-        "Other"
+        "Azure"
     ],
     "keywords": [
         "developer",
         "environment",
         "cloud",
         "azure",
-        "container"
+        "container",
+        "Azure"
     ],
     "activationEvents": [
         "onView:spotExplorer",


### PR DESCRIPTION
I created this PR as there's no mention Azure anywhere in the Spot package.json file, thereby mitigating it's visibility on [the azure category page in the marketplace](https://marketplace.visualstudio.com/search?target=VSCode&category=Azure). This is a **great** extension that I think would be great to highlight on the Azure page. 